### PR TITLE
Add WMA support

### DIFF
--- a/shuffle.py
+++ b/shuffle.py
@@ -15,7 +15,7 @@ import shutil
 import re
 import tempfile
 
-audio_ext = (".mp3", ".m4a", ".m4b", ".m4p", ".aa", ".wav")
+audio_ext = (".mp3", ".m4a", ".m4b", ".m4p", ".aa", ".wav", "wma")
 list_ext = (".pls", ".m3u")
 def make_dir_if_absent(path):
     try:
@@ -475,7 +475,7 @@ class Shuffler(object):
                     fullPath = os.path.abspath(os.path.join(dirpath, filename))
                     relPath = fullPath[fullPath.index(self.path)+len(self.path)+1:].lower()
                     fullPath = os.path.abspath(os.path.join(self.path, relPath));
-                    if os.path.splitext(filename)[1].lower() in (".mp3", ".m4a", ".m4b", ".m4p", ".aa", ".wav"):
+                    if os.path.splitext(filename)[1].lower() in (".mp3", ".m4a", ".m4b", ".m4p", ".aa", ".wav", "wma"):
                         self.tracks.append(fullPath)
                     if os.path.splitext(filename)[1].lower() in (".pls", ".m3u"):
                         self.lists.append(os.path.abspath(os.path.join(dirpath, filename)))


### PR DESCRIPTION
iPod shuffle 4G supports WMA files. This patch takes them into account.