### PR TITLE
fix crash when filename contains '='

### DIFF
--- a/shuffle.py
+++ b/shuffle.py
@@ -373,7 +373,7 @@ class Playlist(Record):
     def populate_pls(self, data):
         sorttracks = []
         for i in data:
-            dataarr = i.strip().split("=")
+            dataarr = i.strip().split("=", 1)
             if dataarr[0].lower().startswith("file"):
                 num = int(dataarr[0][4:])
                 filename = urllib.unquote(dataarr[1]).strip()


### PR DESCRIPTION
Crashed on this filename in the .pls file:

```
File77=Hiromi’s Sonicbloom/Time Control/01.05 - Real Clock vs. Body Clock = Jet Lag.mp3
Title77=Real Clock vs. Body Clock = Jet Lag
```