### PR TITLE
Update iTunesSD3gen.md

### DIFF
--- a/docs/iTunesSD3gen.md
+++ b/docs/iTunesSD3gen.md
@@ -43,7 +43,7 @@ Here's the general layout of an iTunesSD file:<br>
 </td>
         <td>?<br>
 </td>
-        <td><span style="font-family: 'Courier New',Courier,monospace;">0x03000002</span><br>
+        <td><span style="font-family: 'Courier New',Courier,monospace;">0x02000003</span><br>
 </td>
         <td><span style="font-family: 'Courier New',Courier,monospace;">03 00 00 02</span><br>
 </td>


### PR DESCRIPTION
The hex value was written in big endian, but we have little endian. Small mistake. I confirmed this with the rythmbox output.
BTW: We are currently using 0x02010001 for any reason.