### PR TITLE
Fix TypeError when reading playlist files.

### DIFF
--- a/ipod-shuffle-4g.py
+++ b/ipod-shuffle-4g.py
@@ -534,7 +534,7 @@ class Playlist(Record):
                 text = os.path.splitext(os.path.basename(filename))[0]
             else:
                 # Read the playlist file
-                with open(filename, 'rb') as f:
+                with open(filename, 'r', errors="replace") as f:
                     data = f.readlines()
 
                 extension = os.path.splitext(filename)[1].lower()


### PR DESCRIPTION
If there are playlist files being read by the script, upon attempting to read the first playlist file the following will happen: 

```
Traceback (most recent call last):
  File "ipod-shuffle-4g.py", line 780, in <module>
    shuffle.write_database()
  File "ipod-shuffle-4g.py", line 645, in write_database
    f.write(self.tunessd.construct())
  File "ipod-shuffle-4g.py", line 293, in construct
    play_header = self.play_header.construct(self.track_header.tracks)
  File "ipod-shuffle-4g.py", line 429, in construct
    playlist.populate(i)
  File "ipod-shuffle-4g.py", line 542, in populate
    self.listtracks = self.populate_pls(data)
  File "ipod-shuffle-4g.py", line 486, in populate_pls
    dataarr = i.strip().split("=", 1)
TypeError: a bytes-like object is required, not 'str'
```

This is because `populate_pls` and `populate_m3u` both treat the `data` argument as a `str`, e.g. calling `.split` or `.startswith` on them with strings; however, `populate` passes it in as a `bytes` (due to the file being open in `"rb"` mode, not `"r"` mode).&ensp;This stems from how, in Python 3.0+, `bytes` is a stream of bytes whereäs `str` is a stream of Unicode codepoints (in Python 3.3+ and/or on non-Windows) or UTF-16 codewords (on Windows in Python 3.0–3.2), there is no automatic conversion between them, and `str` is supposed to be used only for text, while `bytes` is to be used for arbitrary binary data.

This also seems to be the issue which #49 attempts to address; however, because it converts the text within `populate_pls` rather than at the source, it does not address `populate_m3u` having the some problem.&ensp;It also does not specify an error handler, leaving it to just throw an exception if the playlist file is not valid UTF-8, and inexplicably seems to remove the split limit.&ensp;Hence my differing approach, which also allows me to not specify the encoding and go with Python's default, which is assumed to be a sensible default for the user's operating system.