### PR TITLE
Podcast support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ The file can be found in the [extras](extras) folder.
 #### Compress/Convert your music files
 ([#11](https://github.com/nims11/IPod-Shuffle-4g/issues/11)) Shuffle is short on storage, and you might want to squeeze in more of your collection by sacrificing some bitrate off your files. In rarer cases, you might also possess music in formats not supported by your ipod. Although `ffmpeg` can handle almost all your needs, if you are looking for a friendly alternative, try [Soundconverter](http://soundconverter.org/).
 
+#### Podcast support
+Place podcast tracks in `iPod_Control/Podcasts` to generate playlists. These tracks will be skipped when shuffling, will be marked to remember their last playback position, and won't be included in the "All Songs" playlist.
+
+#### Use symlinks to create playlists
+Symlinks will be followed to their original location on the iPod Shuffle. This allows creating additional playlists without duplicating physical files or duplicate entries in the iTunesSD database.
+
 #### Use Rhythmbox to manage your music and playlists
 As described [in the blog post](https://nims11.wordpress.com/2013/10/12/ipod-shuffle-4g-under-linux/)
 you can use Rythmbox to sync your personal music library to your IPod

--- a/README.md
+++ b/README.md
@@ -96,9 +96,6 @@ The file can be found in the [extras](extras) folder.
 #### Podcast support
 Place podcast tracks in `iPod_Control/Podcasts` to generate playlists. These tracks will be skipped when shuffling, will be marked to remember their last playback position, and won't be included in the "All Songs" playlist.
 
-#### Use symlinks to create playlists
-Symlinks will be followed to their original location on the iPod Shuffle. This allows creating additional playlists without duplicating physical files or duplicate entries in the iTunesSD database.
-
 #### Use Rhythmbox to manage your music and playlists
 As described [in the blog post](https://nims11.wordpress.com/2013/10/12/ipod-shuffle-4g-under-linux/)
 you can use Rythmbox to sync your personal music library to your IPod

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The file can be found in the [extras](extras) folder.
 ([#11](https://github.com/nims11/IPod-Shuffle-4g/issues/11)) Shuffle is short on storage, and you might want to squeeze in more of your collection by sacrificing some bitrate off your files. In rarer cases, you might also possess music in formats not supported by your ipod. Although `ffmpeg` can handle almost all your needs, if you are looking for a friendly alternative, try [Soundconverter](http://soundconverter.org/).
 
 #### Podcast support
-Place podcast tracks in `iPod_Control/Podcasts` to generate playlists. These tracks will be skipped when shuffling, will be marked to remember their last playback position, and won't be included in the "All Songs" playlist.
+Place podcast tracks in `iPod_Control/Podcasts`, or add "Podcast" to the ID3 Genre, to generate playlists. These tracks will be skipped when shuffling, will be marked to remember their last playback position, and won't be included in the "All Songs" playlist.
 
 #### Use Rhythmbox to manage your music and playlists
 As described [in the blog post](https://nims11.wordpress.com/2013/10/12/ipod-shuffle-4g-under-linux/)

--- a/ipod-shuffle-4g.py
+++ b/ipod-shuffle-4g.py
@@ -374,6 +374,7 @@ class Track(Record):
         if "/iPod_Control/Podcasts/" in filename:
             self.is_podcast = True
             self["dontskip"] = 0
+            self["remember"] = 1
 
         text = os.path.splitext(os.path.basename(filename))[0]
 
@@ -388,6 +389,7 @@ class Track(Record):
                 if "Podcast" in audio.get("genre", ["Unknown"]):
                     self.is_podcast = True
                     self["dontskip"] = 0
+                    self["remember"] = 1
 
                 # Note: Rythmbox IPod plugin sets this value always 0.
                 self["stop_at_pos_ms"] = int(audio.info.length * 1000)

--- a/ipod-shuffle-4g.py
+++ b/ipod-shuffle-4g.py
@@ -373,8 +373,8 @@ class Track(Record):
 
         if "/iPod_Control/Podcasts/" in filename:
             self.is_podcast = True
-            self["dontskip"] = 0
-            self["remember"] = 1
+            self["dontskip"] = 0 # podcasts should not be "not skipped" (re: should be skipped) when shuffling
+            self["remember"] = 1 # podcasts should remember their last playback position
 
         text = os.path.splitext(os.path.basename(filename))[0]
 

--- a/ipod-shuffle-4g.py
+++ b/ipod-shuffle-4g.py
@@ -474,7 +474,7 @@ class PlaylistHeader(Record):
             playlist.populate(i)
             construction = playlist.construct(tracks)
             if playlist["number_of_songs"] > 0:
-                if playlist["listtype"] == PlaylistType.PODCAST.value:
+                if PlaylistType(playlist["listtype"]) == PlaylistType.PODCAST:
                     podcastlistcount += 1
                 playlistcount += 1
                 chunks += [construction]

--- a/ipod-shuffle-4g.py
+++ b/ipod-shuffle-4g.py
@@ -337,6 +337,7 @@ class TrackHeader(Record):
         self["number_of_tracks"] = len(self.tracks)
         self["total_length"] = 20 + (len(self.tracks) * 4)
         output = Record.construct(self)
+        self.total_podcasts = 0
 
         # Construct the underlying tracks
         track_chunk = bytes()

--- a/ipod-shuffle-4g.py
+++ b/ipod-shuffle-4g.py
@@ -476,6 +476,9 @@ class PlaylistHeader(Record):
 
         self["number_of_playlists"] = playlistcount
         if podcastlistcount > 0:
+            # "number_of_non_podcast_lists" should default to 65535 if there
+            # aren't any podcast playlists, so only calculate the count  if
+            # the podcastlistcount is greater than 0
             self["number_of_non_podcast_lists"] = playlistcount - podcastlistcount
         self["total_length"] = 0x14 + (self["number_of_playlists"] * 4)
         # Start the header

--- a/ipod-shuffle-4g.py
+++ b/ipod-shuffle-4g.py
@@ -394,8 +394,12 @@ class Track(Record):
     def populate(self, filename):
         self["filename"] = self.path_to_ipod(filename).encode('utf-8')
 
-        if os.path.splitext(filename)[1].lower() in (".m4a", ".m4b", ".m4p", ".aa"):
-            self["filetype"] = 2
+        # assign the "filetype" based on the extension
+        ext = os.path.splitext(filename)[1].lower()
+        for type in FileType:
+            if ext in type.extensions:
+                self.filetype = type.filetype
+                break
 
         if "/iPod_Control/Podcasts/" in filename:
             self.set_podcast()

--- a/ipod-shuffle-4g.py
+++ b/ipod-shuffle-4g.py
@@ -537,8 +537,6 @@ class Playlist(Record):
                     # Only add valid music files to playlist
                     if os.path.splitext(filename)[1].lower() in (".mp3", ".m4a", ".m4b", ".m4p", ".aa", ".wav"):
                         fullPath = os.path.abspath(os.path.join(dirpath, filename))
-                        if os.path.islink(fullPath):
-                            fullPath = os.path.realpath(fullPath)
                         listtracks.append(fullPath)
             if not recursive:
                 break
@@ -649,14 +647,10 @@ class Shuffler(object):
                     # Ignore hidden files
                     if not filename.startswith("."):
                         fullPath = os.path.abspath(os.path.join(dirpath, filename))
-                        if os.path.islink(fullPath):
-                            fullPath = os.path.realpath(fullPath)
                         if os.path.splitext(filename)[1].lower() in (".mp3", ".m4a", ".m4b", ".m4p", ".aa", ".wav"):
-                            if fullPath not in self.tracks:
-                                self.tracks.append(fullPath)
+                            self.tracks.append(fullPath)
                         if os.path.splitext(filename)[1].lower() in (".pls", ".m3u"):
-                            if fullPath not in self.lists:
-                                self.lists.append(fullPath)
+                            self.lists.append(fullPath)
 
             # Create automatic playlists in music directory.
             # Ignore the (music) root and any hidden directories.

--- a/ipod-shuffle-4g.py
+++ b/ipod-shuffle-4g.py
@@ -33,13 +33,15 @@ class FileType(enum.Enum):
     MP3 = (1, {'.mp3'})
     AAC = (2, {'.m4a', '.m4b', '.m4p', '.aa'})
     WAV = (4, {'.wav'})
-
     def __init__(self, filetype, extensions):
         self.filetype = filetype
         self.extensions = extensions
 
+# collect all the supported audio extensions
 audio_ext = functools.reduce(lambda j,k: j.union(k), map(lambda i: i.extensions, FileType))
+# the supported playlist extensions
 list_ext = {".pls", ".m3u"}
+# all the supported file extensions
 all_ext = audio_ext.union(list_ext)
 
 def make_dir_if_absent(path):

--- a/ipod-shuffle-4g.py
+++ b/ipod-shuffle-4g.py
@@ -469,7 +469,7 @@ class PlaylistHeader(Record):
             playlist.populate(i)
             construction = playlist.construct(tracks)
             if playlist["number_of_songs"] > 0:
-                if playlist["listtype"] == 3:
+                if playlist["listtype"] == PlaylistType.PODCAST.value:
                     podcastlistcount += 1
                 playlistcount += 1
                 chunks += [construction]
@@ -518,12 +518,6 @@ class Playlist(Record):
         self.listtype = PlaylistType.ALL_SONGS
         self.listtracks = tracks
 
-    def set_audiobook(self):
-        self.listtype = PlaylistType.AUDIOBOOK
-
-    def set_podcast(self):
-        self.listtype = PlaylistType.PODCAST
-
     def populate_m3u(self, data):
         listtracks = []
         for i in data:
@@ -555,7 +549,7 @@ class Playlist(Record):
         # would generate duplicated playlists. That is intended and "wont fix".
         # Empty folders (inside the music path) will generate an error -> "wont fix".
         if "/iPod_Control/Podcasts/" in playlistpath:
-            self.set_podcast()
+            self.listtype = PlaylistType.PODCAST
         listtracks = []
         for (dirpath, dirnames, filenames) in os.walk(playlistpath):
             dirnames.sort()
@@ -619,8 +613,8 @@ class Playlist(Record):
         for i in self.listtracks:
             path = self.ipod_to_path(i)
             position = -1
-            if self["listtype"] == 1 and "/iPod_Control/Podcasts/" in path:
-                print ('not including podcast in master playlist: {}'.format(path))
+            if PlaylistType.ALL_SONGS == self.listtype and "/iPod_Control/Podcasts/" in path:
+                # exclude podcasts from the "All Songs" playlist
                 continue
             try:
                 position = tracks.index(path)

--- a/ipod-shuffle-4g.py
+++ b/ipod-shuffle-4g.py
@@ -561,7 +561,7 @@ class Playlist(Record):
             if "/." not in dirpath:
                 for filename in sorted(filenames, key = lambda x: x.lower()):
                     # Only add valid music files to playlist
-                    if os.path.splitext(filename)[1].lower() in (".mp3", ".m4a", ".m4b", ".m4p", ".aa", ".wav"):
+                    if os.path.splitext(filename)[1].lower() in audio_ext:
                         fullPath = os.path.abspath(os.path.join(dirpath, filename))
                         listtracks.append(fullPath)
             if not recursive:

--- a/ipod-shuffle-4g.py
+++ b/ipod-shuffle-4g.py
@@ -399,7 +399,7 @@ class Track(Record):
         ext = os.path.splitext(filename)[1].lower()
         for type in FileType:
             if ext in type.extensions:
-                self.filetype = type.filetype
+                self["filetype"] = type.filetype
                 break
 
         if "/iPod_Control/Podcasts/" in filename:

--- a/ipod-shuffle-4g.py
+++ b/ipod-shuffle-4g.py
@@ -589,6 +589,9 @@ class Playlist(Record):
         for i in self.listtracks:
             path = self.ipod_to_path(i)
             position = -1
+            if self["listtype"] == 1 and "/iPod_Control/Podcasts/" in path:
+                print ('not including podcast in master playlist: {}'.format(path))
+                continue
             try:
                 position = tracks.index(path)
             except:

--- a/ipod-shuffle-4g.py
+++ b/ipod-shuffle-4g.py
@@ -510,6 +510,8 @@ class Playlist(Record):
                     # Only add valid music files to playlist
                     if os.path.splitext(filename)[1].lower() in (".mp3", ".m4a", ".m4b", ".m4p", ".aa", ".wav"):
                         fullPath = os.path.abspath(os.path.join(dirpath, filename))
+                        if os.path.islink(fullPath):
+                            fullPath = os.path.realpath(fullPath)
                         listtracks.append(fullPath)
             if not recursive:
                 break
@@ -617,14 +619,18 @@ class Shuffler(object):
                     # Ignore hidden files
                     if not filename.startswith("."):
                         fullPath = os.path.abspath(os.path.join(dirpath, filename))
+                        if os.path.islink(fullPath):
+                            fullPath = os.path.realpath(fullPath)
                         if os.path.splitext(filename)[1].lower() in (".mp3", ".m4a", ".m4b", ".m4p", ".aa", ".wav"):
-                            self.tracks.append(fullPath)
+                            if fullPath not in self.tracks:
+                                self.tracks.append(fullPath)
                         if os.path.splitext(filename)[1].lower() in (".pls", ".m3u"):
-                            self.lists.append(fullPath)
+                            if fullPath not in self.lists:
+                                self.lists.append(fullPath)
 
             # Create automatic playlists in music directory.
             # Ignore the (music) root and any hidden directories.
-            if self.auto_dir_playlists and "iPod_Control/Music/" in dirpath and "/." not in dirpath:
+            if self.auto_dir_playlists and ("iPod_Control/Music/" in dirpath or "iPod_Control/Podcasts/" in dirpath) and "/." not in dirpath:
                 # Only go to a specific depth. -1 is unlimted, 0 is ignored as there is already a master playlist.
                 depth = dirpath[len(self.path) + len(os.path.sep):].count(os.path.sep) - 1
                 if self.auto_dir_playlists < 0 or depth <= self.auto_dir_playlists:

--- a/ipod-shuffle-4g.py
+++ b/ipod-shuffle-4g.py
@@ -452,7 +452,7 @@ class PlaylistHeader(Record):
                           ("header_id", ("4s", b"hphs")), #shph
                           ("total_length", ("I", 0)),
                           ("number_of_playlists", ("I", 0)),
-                          ("number_of_non_podcast_lists", ("H", 65535)),
+                          ("number_of_non_podcast_lists", ("H", b"\xFF\xFF")),
                           ("number_of_master_lists", ("2s", b"\x01\x00")),
                           ("number_of_non_audiobook_lists", ("2s", b"\xFF\xFF")),
                           ("unknown2", ("2s", b"\x00" * 2)),
@@ -483,7 +483,7 @@ class PlaylistHeader(Record):
 
         self["number_of_playlists"] = playlistcount
         if podcastlistcount > 0:
-            # "number_of_non_podcast_lists" should default to 65535 if there
+            # "number_of_non_podcast_lists" should default to 0xFFFF if there
             # aren't any podcast playlists, so only calculate the count  if
             # the podcastlistcount is greater than 0
             self["number_of_non_podcast_lists"] = playlistcount - podcastlistcount

--- a/ipod-shuffle-4g.py
+++ b/ipod-shuffle-4g.py
@@ -623,7 +623,7 @@ class Shuffler(object):
       # remove existing voiceover files (they are either useless or will be overwritten anyway)
       for dirname in ('iPod_Control/Speakable/Playlists', 'iPod_Control/Speakable/Tracks'):
           shutil.rmtree(os.path.join(self.path, dirname), ignore_errors=True)
-      for dirname in ('iPod_Control/iTunes', 'iPod_Control/Music', 'iPod_Control/Speakable/Playlists', 'iPod_Control/Speakable/Tracks'):
+      for dirname in ('iPod_Control/iTunes', 'iPod_Control/Music', 'iPod_Control/Podcasts', 'iPod_Control/Speakable/Playlists', 'iPod_Control/Speakable/Tracks'):
           make_dir_if_absent(os.path.join(self.path, dirname))
 
     def dump_state(self):

--- a/ipod-shuffle-4g.py
+++ b/ipod-shuffle-4g.py
@@ -553,8 +553,6 @@ class Playlist(Record):
         # Folders containing no music and only a single Album
         # would generate duplicated playlists. That is intended and "wont fix".
         # Empty folders (inside the music path) will generate an error -> "wont fix".
-        if "/iPod_Control/Podcasts/" in playlistpath:
-            self.listtype = PlaylistType.PODCAST
         listtracks = []
         for (dirpath, dirnames, filenames) in os.walk(playlistpath):
             dirnames.sort()
@@ -584,6 +582,8 @@ class Playlist(Record):
             text = obj[0]
         else:
             filename = obj
+            if "/iPod_Control/Podcasts/" in filename:
+                self.listtype = PlaylistType.PODCAST
             if os.path.isdir(filename):
                 self.listtracks = self.populate_directory(filename)
                 text = os.path.splitext(os.path.basename(filename))[0]


### PR DESCRIPTION
Adds podcast support. This consists of treating tracks specially if they're found in the `iPod_Control/Podcasts` directory or if metadata contains "Podcast" in the genre list. Identified podcast tracks are excluded from the "All Songs" playlist and skipped when shuffling. In support of this, a Podcasts directory will be created when the script is run and symlinks will be followed to support creating playlists (this will aid regular music tracks as well).